### PR TITLE
Using protobuffers instead of msgpack

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -38,12 +38,22 @@ jobs:
     - name: Publish snapshot version
       if: github.event_name == 'pull_request'
       run: |
-        npm --no-git-tag-version version $(npm view @tradepump/types version)-snapshot.$(date +%s)
+        version=$(node -e "console.log(require('./package.json').version)")
+        npm --no-git-tag-version version ${version}-snapshot.$(date +%s)
         npm publish
       working-directory: services/types
     - name: Publish relese
       if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-      run: npm publish
+      run: |
+        currentVersion=$(node -e "console.log(require('./package.json').version)")
+        npm view @tradepump/types versions > tmp.json
+        latestSolid=$(node -e "console.log(require('./tmp.json').filter(v => v.indexOf('snapshot') === -1).pop())")
+        rm tmp.json
+        if [[ "$currentVersion" != "$latestSolid" ]]; then
+          npm publish
+        else
+          echo "Same version is published, skipping..."
+        fi
       working-directory: services/types
 
   build:

--- a/services/harvester/package-lock.json
+++ b/services/harvester/package-lock.json
@@ -4,15 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@msgpack/msgpack": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.7.0.tgz",
-      "integrity": "sha512-mlRYq9FSsOd4m+3wZWatemn3hGFZPWNJ4JQOdrir4rrMK2PyIk26idKBoUWrqF3HJJHl+5GpRU+M0wEruJwecg=="
-    },
     "@tradepump/types": {
-      "version": "1.0.0",
-      "resolved": "https://gitlab.com/api/v4/projects/26965542/packages/npm/@tradepump/types/-/@tradepump/types-1.0.0.tgz",
-      "integrity": "sha1-42FFh8ynKspm5jfHV4L/0p+l/lY="
+      "version": "2.0.2",
+      "resolved": "https://gitlab.com/api/v4/projects/26965542/packages/npm/@tradepump/types/-/@tradepump/types-2.0.2.tgz",
+      "integrity": "sha1-+cv1oEQSEWZUIhQAuW2vjPdpkW8="
     },
     "@types/amqplib": {
       "version": "0.5.17",

--- a/services/harvester/package.json
+++ b/services/harvester/package.json
@@ -12,8 +12,7 @@
   "author": "Soul_man",
   "license": "ISC",
   "dependencies": {
-    "@msgpack/msgpack": "^2.7.0",
-    "@tradepump/types": "^1.0.0",
+    "@tradepump/types": "^2.0.2",
     "amqplib": "^0.8.0",
     "log4js": "^6.3.0",
     "ws": "^7.4.5"

--- a/services/harvester/src/index.ts
+++ b/services/harvester/src/index.ts
@@ -1,10 +1,9 @@
 import { getLogger } from 'log4js';
-import { encode } from '@msgpack/msgpack';
-import { isCurrencyPair } from '@tradepump/types';
+import { isCurrencyPair, encodeBookMessage, encodeTradeMessage, BookModel, TradeModel } from '@tradepump/types';
 import { setupLog4js } from './config/logging';
 import { QueueManager } from './lib/QueueManager';
 import { KrakenSocket } from './lib/KrakenSocket';
-import { actions } from './lib/common/DataActions';
+import { actions, DataEvent } from './lib/common/DataActions';
 
 const RABBITMQ_URL = process.env.RABBITMQ_URL || 'amqp://guest:guest@localhost';
 const DEFAULT_PAIRS = (process.env.TRADING_PAIRS || 'BTC/EUR,BTC/USD,BTC/USDT')
@@ -21,7 +20,10 @@ async function init(): Promise<[KrakenSocket]> {
   logger.info(`Initializing QueueManager...`);
   await QueueManager.init(RABBITMQ_URL);
   const sendToTradingQueue = (action: actions) => {
-    const uintArr = encode(action.payload);
+    const uintArr = action.type === DataEvent.BOOK_UPDATE
+      ? encodeBookMessage({ models: action.payload as BookModel[] })
+      : encodeTradeMessage({ models: action.payload as TradeModel[] });
+
     QueueManager.sendToQueue('trading_queue', Buffer.from(uintArr.buffer, uintArr.byteOffset, uintArr.byteLength));
   };
 

--- a/services/harvester/src/lib/KrakenSocket/utils.ts
+++ b/services/harvester/src/lib/KrakenSocket/utils.ts
@@ -22,10 +22,10 @@ export const parseKrakenPayload = (payload: KrakenPayload) => {
   switch (payload[2]) {
     case 'trade':
       return payload[1].map<TradeModel>(item => ({
-        market: MarketType.Kraken,
+        market: MarketType.kraken,
         pair,
-        type: item[4] === 'l' ? OrderType.Limit : OrderType.Market,
-        side: item[3] === 's' ? TradeSide.Sell : TradeSide.Sell,
+        type: item[4] === 'l' ? OrderType.limit : OrderType.market,
+        side: item[3] === 's' ? TradeSide.sell : TradeSide.sell,
         price: parseFloat(item[0]),
         volume: parseFloat(item[1]),
         time: parseFloat(item[2]) * 1000,
@@ -44,13 +44,13 @@ export const parseKrakenPayload = (payload: KrakenPayload) => {
       }
 
       return (payload[1].as || payload[1].a || []).map<BookModel>(item => ({
-          side: BookSide.Ask,
+          side: BookSide.ask,
           price: parseFloat(item[0]),
           volume: parseFloat(item[1]),
           time: parseFloat(item[2]) * 1000,
         })).concat(
           (payload[1].bs || payload[1].b || []).map<BookModel>(item => ({
-            side: BookSide.Bid,
+            side: BookSide.bid,
             price: parseFloat(item[0]),
             volume: parseFloat(item[1]),
             time: parseFloat(item[2]) * 1000,

--- a/services/harvester/src/lib/QueueManager.ts
+++ b/services/harvester/src/lib/QueueManager.ts
@@ -89,6 +89,8 @@ export class QueueManager extends EventEmitter {
     await channel.assertQueue(queue, {
       // We don't want to loose trades
       durable: true,
+      // Let's limit to 100k for now. It's over 1m after few hours
+      maxLength: 100000,
     });
     logger.trace(`Sending message (${data.byteLength} bytes)...`);
 

--- a/services/harvester/src/utils/guards.ts
+++ b/services/harvester/src/utils/guards.ts
@@ -9,5 +9,5 @@ export const isKrakenPayload = (payload: any): payload is KrakenPayload => (
 );
 export const isBookTrade = (bookModels: any[]): bookModels is BookModel[] => bookModels.every(bookModel => (
   'side' in bookModel
-  && (bookModel.side === BookSide.Ask || bookModel.side === BookSide.Bid)
+  && (bookModel.side === BookSide.ask || bookModel.side === BookSide.bid)
 ));

--- a/services/types/.npmignore
+++ b/services/types/.npmignore
@@ -1,2 +1,4 @@
 src
 tsconfig.json
+scripts
+protobuf

--- a/services/types/package-lock.json
+++ b/services/types/package-lock.json
@@ -1,9 +1,31 @@
 {
   "name": "@tradepump/types",
-  "version": "1.0.2",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "commander": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.0.1.tgz",
+      "integrity": "sha512-IPF4ouhCP+qdlcmCedhxX4xiGBPyigb8v5NeUp+0LyhwLgxMqyp3S0vl7TAPfS/hiP7FC3caI/PB9lTmP8r1NA==",
+      "dev": true
+    },
+    "pbjs": {
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/pbjs/-/pbjs-0.0.14.tgz",
+      "integrity": "sha512-F4aA0ojrQ37kxFPOg4yRLP/vxb76rYQwMQigmVEljYlA7hZKmjaWjP6IkRn4nA0NdIj4Xxe4iqWrrIhJy+MwWQ==",
+      "dev": true,
+      "requires": {
+        "commander": "4.0.1",
+        "protocol-buffers-schema": "3.1.0"
+      }
+    },
+    "protocol-buffers-schema": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.1.0.tgz",
+      "integrity": "sha1-2KgZVJ6tPmvRievp5Q6WY2u8XMc=",
+      "dev": true
+    },
     "typescript": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",

--- a/services/types/package.json
+++ b/services/types/package.json
@@ -1,11 +1,14 @@
 {
   "name": "@tradepump/types",
-  "version": "1.0.2",
+  "version": "2.0.2",
   "description": "Types and models",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "npm run build:proto && npm run build:ts",
+    "build:proto": "node scripts/buildProto.js",
+    "build:ts": "tsc",
+    "update-version": "npm --no-git-tag-version version",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "publishConfig": {
@@ -16,6 +19,7 @@
   "author": "Tradepump",
   "license": "ISC",
   "devDependencies": {
-    "typescript": "^4.3.2"
+    "typescript": "^4.3.2",
+    "pbjs": "0.0.14"
   }
 }

--- a/services/types/protobuf/BookModel.proto
+++ b/services/types/protobuf/BookModel.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+package types;
+
+enum BookSide {
+  bid = 0;
+  ask = 1;
+}
+
+message BookModel {
+  required BookSide side = 1;
+  required float price = 2;
+  required float volume = 3;
+  required float time = 4;
+}
+
+message BookMessage {
+  repeated BookModel models = 1;
+}

--- a/services/types/protobuf/TradeModel.proto
+++ b/services/types/protobuf/TradeModel.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+package types;
+
+enum TradeSide {
+  buy = 0;
+  sell = 1;
+}
+
+enum OrderType {
+  market = 0;
+  limit = 1;
+}
+
+enum MarketType {
+  kraken = 0;
+  bitfinex = 1;
+}
+
+message TradeModel {
+  string pair = 1;
+  float price = 2;
+  float volume = 3;
+  float time = 4;
+  TradeSide side = 5;
+  OrderType type = 6;
+  MarketType market = 7;
+}
+
+message TradeMessage {
+  repeated TradeModel models = 1;
+}

--- a/services/types/scripts/buildProto.js
+++ b/services/types/scripts/buildProto.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const { execSync } = require('child_process');
+const path = require('path');
+
+const resolveNPMBin = execFile => path.resolve(__dirname, '..', 'node_modules', '.bin', execFile);
+const protoPath = fileName => path.resolve(__dirname, '..', 'protobuf', fileName);
+const srcPath = fileName => path.resolve(__dirname, '..', 'src', fileName);
+
+try {
+  fs.readdirSync(path.resolve(__dirname, '..', 'protobuf')).forEach(fileName => {
+    const cmd = [
+      resolveNPMBin('pbjs'),
+      '--ts',
+      srcPath(path.basename(fileName, '.proto') + '.ts'),
+      protoPath(fileName),
+    ];
+    execSync(cmd.join(' '));
+  });
+} catch (err) {
+  if (err.signal) {
+    console.error(err.stdout.toString());
+    console.error(err.stderr.toString());
+  } else {
+    console.error(err);
+  } 
+}

--- a/services/types/src/BookModel.ts
+++ b/services/types/src/BookModel.ts
@@ -1,11 +1,664 @@
 export const enum BookSide {
-  Bid = 'bid',
-  Ask = 'ask',
+  bid = "bid",
+  ask = "ask",
 }
+
+export const encodeBookSide: { [key: string]: number } = {
+  bid: 0,
+  ask: 1,
+};
+
+export const decodeBookSide: { [key: number]: BookSide } = {
+  0: BookSide.bid,
+  1: BookSide.ask,
+};
 
 export interface BookModel {
   side: BookSide;
   price: number;
   volume: number;
   time: number;
+}
+
+export function encodeBookModel(message: BookModel): Uint8Array {
+  let bb = popByteBuffer();
+  _encodeBookModel(message, bb);
+  return toUint8Array(bb);
+}
+
+function _encodeBookModel(message: BookModel, bb: ByteBuffer): void {
+  // required BookSide side = 1;
+  let $side = message.side;
+  if ($side !== undefined) {
+    writeVarint32(bb, 8);
+    writeVarint32(bb, encodeBookSide[$side]);
+  }
+
+  // required float price = 2;
+  let $price = message.price;
+  if ($price !== undefined) {
+    writeVarint32(bb, 21);
+    writeFloat(bb, $price);
+  }
+
+  // required float volume = 3;
+  let $volume = message.volume;
+  if ($volume !== undefined) {
+    writeVarint32(bb, 29);
+    writeFloat(bb, $volume);
+  }
+
+  // required float time = 4;
+  let $time = message.time;
+  if ($time !== undefined) {
+    writeVarint32(bb, 37);
+    writeFloat(bb, $time);
+  }
+}
+
+export function decodeBookModel(binary: Uint8Array): BookModel {
+  return _decodeBookModel(wrapByteBuffer(binary));
+}
+
+function _decodeBookModel(bb: ByteBuffer): BookModel {
+  let message: BookModel = {} as any;
+
+  end_of_message: while (!isAtEnd(bb)) {
+    let tag = readVarint32(bb);
+
+    switch (tag >>> 3) {
+      case 0:
+        break end_of_message;
+
+      // required BookSide side = 1;
+      case 1: {
+        message.side = decodeBookSide[readVarint32(bb)];
+        break;
+      }
+
+      // required float price = 2;
+      case 2: {
+        message.price = readFloat(bb);
+        break;
+      }
+
+      // required float volume = 3;
+      case 3: {
+        message.volume = readFloat(bb);
+        break;
+      }
+
+      // required float time = 4;
+      case 4: {
+        message.time = readFloat(bb);
+        break;
+      }
+
+      default:
+        skipUnknownField(bb, tag & 7);
+    }
+  }
+
+  if (message.side === undefined)
+    throw new Error("Missing required field: side");
+
+  if (message.price === undefined)
+    throw new Error("Missing required field: price");
+
+  if (message.volume === undefined)
+    throw new Error("Missing required field: volume");
+
+  if (message.time === undefined)
+    throw new Error("Missing required field: time");
+
+  return message;
+}
+
+export interface BookMessage {
+  models?: BookModel[];
+}
+
+export function encodeBookMessage(message: BookMessage): Uint8Array {
+  let bb = popByteBuffer();
+  _encodeBookMessage(message, bb);
+  return toUint8Array(bb);
+}
+
+function _encodeBookMessage(message: BookMessage, bb: ByteBuffer): void {
+  // repeated BookModel models = 1;
+  let array$models = message.models;
+  if (array$models !== undefined) {
+    for (let value of array$models) {
+      writeVarint32(bb, 10);
+      let nested = popByteBuffer();
+      _encodeBookModel(value, nested);
+      writeVarint32(bb, nested.limit);
+      writeByteBuffer(bb, nested);
+      pushByteBuffer(nested);
+    }
+  }
+}
+
+export function decodeBookMessage(binary: Uint8Array): BookMessage {
+  return _decodeBookMessage(wrapByteBuffer(binary));
+}
+
+function _decodeBookMessage(bb: ByteBuffer): BookMessage {
+  let message: BookMessage = {} as any;
+
+  end_of_message: while (!isAtEnd(bb)) {
+    let tag = readVarint32(bb);
+
+    switch (tag >>> 3) {
+      case 0:
+        break end_of_message;
+
+      // repeated BookModel models = 1;
+      case 1: {
+        let limit = pushTemporaryLength(bb);
+        let values = message.models || (message.models = []);
+        values.push(_decodeBookModel(bb));
+        bb.limit = limit;
+        break;
+      }
+
+      default:
+        skipUnknownField(bb, tag & 7);
+    }
+  }
+
+  return message;
+}
+
+export interface Long {
+  low: number;
+  high: number;
+  unsigned: boolean;
+}
+
+interface ByteBuffer {
+  bytes: Uint8Array;
+  offset: number;
+  limit: number;
+}
+
+function pushTemporaryLength(bb: ByteBuffer): number {
+  let length = readVarint32(bb);
+  let limit = bb.limit;
+  bb.limit = bb.offset + length;
+  return limit;
+}
+
+function skipUnknownField(bb: ByteBuffer, type: number): void {
+  switch (type) {
+    case 0: while (readByte(bb) & 0x80) { } break;
+    case 2: skip(bb, readVarint32(bb)); break;
+    case 5: skip(bb, 4); break;
+    case 1: skip(bb, 8); break;
+    default: throw new Error("Unimplemented type: " + type);
+  }
+}
+
+function stringToLong(value: string): Long {
+  return {
+    low: value.charCodeAt(0) | (value.charCodeAt(1) << 16),
+    high: value.charCodeAt(2) | (value.charCodeAt(3) << 16),
+    unsigned: false,
+  };
+}
+
+function longToString(value: Long): string {
+  let low = value.low;
+  let high = value.high;
+  return String.fromCharCode(
+    low & 0xFFFF,
+    low >>> 16,
+    high & 0xFFFF,
+    high >>> 16);
+}
+
+// The code below was modified from https://github.com/protobufjs/bytebuffer.js
+// which is under the Apache License 2.0.
+
+let f32 = new Float32Array(1);
+let f32_u8 = new Uint8Array(f32.buffer);
+
+let f64 = new Float64Array(1);
+let f64_u8 = new Uint8Array(f64.buffer);
+
+function intToLong(value: number): Long {
+  value |= 0;
+  return {
+    low: value,
+    high: value >> 31,
+    unsigned: value >= 0,
+  };
+}
+
+let bbStack: ByteBuffer[] = [];
+
+function popByteBuffer(): ByteBuffer {
+  const bb = bbStack.pop();
+  if (!bb) return { bytes: new Uint8Array(64), offset: 0, limit: 0 };
+  bb.offset = bb.limit = 0;
+  return bb;
+}
+
+function pushByteBuffer(bb: ByteBuffer): void {
+  bbStack.push(bb);
+}
+
+function wrapByteBuffer(bytes: Uint8Array): ByteBuffer {
+  return { bytes, offset: 0, limit: bytes.length };
+}
+
+function toUint8Array(bb: ByteBuffer): Uint8Array {
+  let bytes = bb.bytes;
+  let limit = bb.limit;
+  return bytes.length === limit ? bytes : bytes.subarray(0, limit);
+}
+
+function skip(bb: ByteBuffer, offset: number): void {
+  if (bb.offset + offset > bb.limit) {
+    throw new Error('Skip past limit');
+  }
+  bb.offset += offset;
+}
+
+function isAtEnd(bb: ByteBuffer): boolean {
+  return bb.offset >= bb.limit;
+}
+
+function grow(bb: ByteBuffer, count: number): number {
+  let bytes = bb.bytes;
+  let offset = bb.offset;
+  let limit = bb.limit;
+  let finalOffset = offset + count;
+  if (finalOffset > bytes.length) {
+    let newBytes = new Uint8Array(finalOffset * 2);
+    newBytes.set(bytes);
+    bb.bytes = newBytes;
+  }
+  bb.offset = finalOffset;
+  if (finalOffset > limit) {
+    bb.limit = finalOffset;
+  }
+  return offset;
+}
+
+function advance(bb: ByteBuffer, count: number): number {
+  let offset = bb.offset;
+  if (offset + count > bb.limit) {
+    throw new Error('Read past limit');
+  }
+  bb.offset += count;
+  return offset;
+}
+
+function readBytes(bb: ByteBuffer, count: number): Uint8Array {
+  let offset = advance(bb, count);
+  return bb.bytes.subarray(offset, offset + count);
+}
+
+function writeBytes(bb: ByteBuffer, buffer: Uint8Array): void {
+  let offset = grow(bb, buffer.length);
+  bb.bytes.set(buffer, offset);
+}
+
+function readString(bb: ByteBuffer, count: number): string {
+  // Sadly a hand-coded UTF8 decoder is much faster than subarray+TextDecoder in V8
+  let offset = advance(bb, count);
+  let fromCharCode = String.fromCharCode;
+  let bytes = bb.bytes;
+  let invalid = '\uFFFD';
+  let text = '';
+
+  for (let i = 0; i < count; i++) {
+    let c1 = bytes[i + offset], c2: number, c3: number, c4: number, c: number;
+
+    // 1 byte
+    if ((c1 & 0x80) === 0) {
+      text += fromCharCode(c1);
+    }
+
+    // 2 bytes
+    else if ((c1 & 0xE0) === 0xC0) {
+      if (i + 1 >= count) text += invalid;
+      else {
+        c2 = bytes[i + offset + 1];
+        if ((c2 & 0xC0) !== 0x80) text += invalid;
+        else {
+          c = ((c1 & 0x1F) << 6) | (c2 & 0x3F);
+          if (c < 0x80) text += invalid;
+          else {
+            text += fromCharCode(c);
+            i++;
+          }
+        }
+      }
+    }
+
+    // 3 bytes
+    else if ((c1 & 0xF0) == 0xE0) {
+      if (i + 2 >= count) text += invalid;
+      else {
+        c2 = bytes[i + offset + 1];
+        c3 = bytes[i + offset + 2];
+        if (((c2 | (c3 << 8)) & 0xC0C0) !== 0x8080) text += invalid;
+        else {
+          c = ((c1 & 0x0F) << 12) | ((c2 & 0x3F) << 6) | (c3 & 0x3F);
+          if (c < 0x0800 || (c >= 0xD800 && c <= 0xDFFF)) text += invalid;
+          else {
+            text += fromCharCode(c);
+            i += 2;
+          }
+        }
+      }
+    }
+
+    // 4 bytes
+    else if ((c1 & 0xF8) == 0xF0) {
+      if (i + 3 >= count) text += invalid;
+      else {
+        c2 = bytes[i + offset + 1];
+        c3 = bytes[i + offset + 2];
+        c4 = bytes[i + offset + 3];
+        if (((c2 | (c3 << 8) | (c4 << 16)) & 0xC0C0C0) !== 0x808080) text += invalid;
+        else {
+          c = ((c1 & 0x07) << 0x12) | ((c2 & 0x3F) << 0x0C) | ((c3 & 0x3F) << 0x06) | (c4 & 0x3F);
+          if (c < 0x10000 || c > 0x10FFFF) text += invalid;
+          else {
+            c -= 0x10000;
+            text += fromCharCode((c >> 10) + 0xD800, (c & 0x3FF) + 0xDC00);
+            i += 3;
+          }
+        }
+      }
+    }
+
+    else text += invalid;
+  }
+
+  return text;
+}
+
+function writeString(bb: ByteBuffer, text: string): void {
+  // Sadly a hand-coded UTF8 encoder is much faster than TextEncoder+set in V8
+  let n = text.length;
+  let byteCount = 0;
+
+  // Write the byte count first
+  for (let i = 0; i < n; i++) {
+    let c = text.charCodeAt(i);
+    if (c >= 0xD800 && c <= 0xDBFF && i + 1 < n) {
+      c = (c << 10) + text.charCodeAt(++i) - 0x35FDC00;
+    }
+    byteCount += c < 0x80 ? 1 : c < 0x800 ? 2 : c < 0x10000 ? 3 : 4;
+  }
+  writeVarint32(bb, byteCount);
+
+  let offset = grow(bb, byteCount);
+  let bytes = bb.bytes;
+
+  // Then write the bytes
+  for (let i = 0; i < n; i++) {
+    let c = text.charCodeAt(i);
+    if (c >= 0xD800 && c <= 0xDBFF && i + 1 < n) {
+      c = (c << 10) + text.charCodeAt(++i) - 0x35FDC00;
+    }
+    if (c < 0x80) {
+      bytes[offset++] = c;
+    } else {
+      if (c < 0x800) {
+        bytes[offset++] = ((c >> 6) & 0x1F) | 0xC0;
+      } else {
+        if (c < 0x10000) {
+          bytes[offset++] = ((c >> 12) & 0x0F) | 0xE0;
+        } else {
+          bytes[offset++] = ((c >> 18) & 0x07) | 0xF0;
+          bytes[offset++] = ((c >> 12) & 0x3F) | 0x80;
+        }
+        bytes[offset++] = ((c >> 6) & 0x3F) | 0x80;
+      }
+      bytes[offset++] = (c & 0x3F) | 0x80;
+    }
+  }
+}
+
+function writeByteBuffer(bb: ByteBuffer, buffer: ByteBuffer): void {
+  let offset = grow(bb, buffer.limit);
+  let from = bb.bytes;
+  let to = buffer.bytes;
+
+  // This for loop is much faster than subarray+set on V8
+  for (let i = 0, n = buffer.limit; i < n; i++) {
+    from[i + offset] = to[i];
+  }
+}
+
+function readByte(bb: ByteBuffer): number {
+  return bb.bytes[advance(bb, 1)];
+}
+
+function writeByte(bb: ByteBuffer, value: number): void {
+  let offset = grow(bb, 1);
+  bb.bytes[offset] = value;
+}
+
+function readFloat(bb: ByteBuffer): number {
+  let offset = advance(bb, 4);
+  let bytes = bb.bytes;
+
+  // Manual copying is much faster than subarray+set in V8
+  f32_u8[0] = bytes[offset++];
+  f32_u8[1] = bytes[offset++];
+  f32_u8[2] = bytes[offset++];
+  f32_u8[3] = bytes[offset++];
+  return f32[0];
+}
+
+function writeFloat(bb: ByteBuffer, value: number): void {
+  let offset = grow(bb, 4);
+  let bytes = bb.bytes;
+  f32[0] = value;
+
+  // Manual copying is much faster than subarray+set in V8
+  bytes[offset++] = f32_u8[0];
+  bytes[offset++] = f32_u8[1];
+  bytes[offset++] = f32_u8[2];
+  bytes[offset++] = f32_u8[3];
+}
+
+function readDouble(bb: ByteBuffer): number {
+  let offset = advance(bb, 8);
+  let bytes = bb.bytes;
+
+  // Manual copying is much faster than subarray+set in V8
+  f64_u8[0] = bytes[offset++];
+  f64_u8[1] = bytes[offset++];
+  f64_u8[2] = bytes[offset++];
+  f64_u8[3] = bytes[offset++];
+  f64_u8[4] = bytes[offset++];
+  f64_u8[5] = bytes[offset++];
+  f64_u8[6] = bytes[offset++];
+  f64_u8[7] = bytes[offset++];
+  return f64[0];
+}
+
+function writeDouble(bb: ByteBuffer, value: number): void {
+  let offset = grow(bb, 8);
+  let bytes = bb.bytes;
+  f64[0] = value;
+
+  // Manual copying is much faster than subarray+set in V8
+  bytes[offset++] = f64_u8[0];
+  bytes[offset++] = f64_u8[1];
+  bytes[offset++] = f64_u8[2];
+  bytes[offset++] = f64_u8[3];
+  bytes[offset++] = f64_u8[4];
+  bytes[offset++] = f64_u8[5];
+  bytes[offset++] = f64_u8[6];
+  bytes[offset++] = f64_u8[7];
+}
+
+function readInt32(bb: ByteBuffer): number {
+  let offset = advance(bb, 4);
+  let bytes = bb.bytes;
+  return (
+    bytes[offset] |
+    (bytes[offset + 1] << 8) |
+    (bytes[offset + 2] << 16) |
+    (bytes[offset + 3] << 24)
+  );
+}
+
+function writeInt32(bb: ByteBuffer, value: number): void {
+  let offset = grow(bb, 4);
+  let bytes = bb.bytes;
+  bytes[offset] = value;
+  bytes[offset + 1] = value >> 8;
+  bytes[offset + 2] = value >> 16;
+  bytes[offset + 3] = value >> 24;
+}
+
+function readInt64(bb: ByteBuffer, unsigned: boolean): Long {
+  return {
+    low: readInt32(bb),
+    high: readInt32(bb),
+    unsigned,
+  };
+}
+
+function writeInt64(bb: ByteBuffer, value: Long): void {
+  writeInt32(bb, value.low);
+  writeInt32(bb, value.high);
+}
+
+function readVarint32(bb: ByteBuffer): number {
+  let c = 0;
+  let value = 0;
+  let b: number;
+  do {
+    b = readByte(bb);
+    if (c < 32) value |= (b & 0x7F) << c;
+    c += 7;
+  } while (b & 0x80);
+  return value;
+}
+
+function writeVarint32(bb: ByteBuffer, value: number): void {
+  value >>>= 0;
+  while (value >= 0x80) {
+    writeByte(bb, (value & 0x7f) | 0x80);
+    value >>>= 7;
+  }
+  writeByte(bb, value);
+}
+
+function readVarint64(bb: ByteBuffer, unsigned: boolean): Long {
+  let part0 = 0;
+  let part1 = 0;
+  let part2 = 0;
+  let b: number;
+
+  b = readByte(bb); part0 = (b & 0x7F); if (b & 0x80) {
+    b = readByte(bb); part0 |= (b & 0x7F) << 7; if (b & 0x80) {
+      b = readByte(bb); part0 |= (b & 0x7F) << 14; if (b & 0x80) {
+        b = readByte(bb); part0 |= (b & 0x7F) << 21; if (b & 0x80) {
+
+          b = readByte(bb); part1 = (b & 0x7F); if (b & 0x80) {
+            b = readByte(bb); part1 |= (b & 0x7F) << 7; if (b & 0x80) {
+              b = readByte(bb); part1 |= (b & 0x7F) << 14; if (b & 0x80) {
+                b = readByte(bb); part1 |= (b & 0x7F) << 21; if (b & 0x80) {
+
+                  b = readByte(bb); part2 = (b & 0x7F); if (b & 0x80) {
+                    b = readByte(bb); part2 |= (b & 0x7F) << 7;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    low: part0 | (part1 << 28),
+    high: (part1 >>> 4) | (part2 << 24),
+    unsigned,
+  };
+}
+
+function writeVarint64(bb: ByteBuffer, value: Long): void {
+  let part0 = value.low >>> 0;
+  let part1 = ((value.low >>> 28) | (value.high << 4)) >>> 0;
+  let part2 = value.high >>> 24;
+
+  // ref: src/google/protobuf/io/coded_stream.cc
+  let size =
+    part2 === 0 ?
+      part1 === 0 ?
+        part0 < 1 << 14 ?
+          part0 < 1 << 7 ? 1 : 2 :
+          part0 < 1 << 21 ? 3 : 4 :
+        part1 < 1 << 14 ?
+          part1 < 1 << 7 ? 5 : 6 :
+          part1 < 1 << 21 ? 7 : 8 :
+      part2 < 1 << 7 ? 9 : 10;
+
+  let offset = grow(bb, size);
+  let bytes = bb.bytes;
+
+  switch (size) {
+    case 10: bytes[offset + 9] = (part2 >>> 7) & 0x01;
+    case 9: bytes[offset + 8] = size !== 9 ? part2 | 0x80 : part2 & 0x7F;
+    case 8: bytes[offset + 7] = size !== 8 ? (part1 >>> 21) | 0x80 : (part1 >>> 21) & 0x7F;
+    case 7: bytes[offset + 6] = size !== 7 ? (part1 >>> 14) | 0x80 : (part1 >>> 14) & 0x7F;
+    case 6: bytes[offset + 5] = size !== 6 ? (part1 >>> 7) | 0x80 : (part1 >>> 7) & 0x7F;
+    case 5: bytes[offset + 4] = size !== 5 ? part1 | 0x80 : part1 & 0x7F;
+    case 4: bytes[offset + 3] = size !== 4 ? (part0 >>> 21) | 0x80 : (part0 >>> 21) & 0x7F;
+    case 3: bytes[offset + 2] = size !== 3 ? (part0 >>> 14) | 0x80 : (part0 >>> 14) & 0x7F;
+    case 2: bytes[offset + 1] = size !== 2 ? (part0 >>> 7) | 0x80 : (part0 >>> 7) & 0x7F;
+    case 1: bytes[offset] = size !== 1 ? part0 | 0x80 : part0 & 0x7F;
+  }
+}
+
+function readVarint32ZigZag(bb: ByteBuffer): number {
+  let value = readVarint32(bb);
+
+  // ref: src/google/protobuf/wire_format_lite.h
+  return (value >>> 1) ^ -(value & 1);
+}
+
+function writeVarint32ZigZag(bb: ByteBuffer, value: number): void {
+  // ref: src/google/protobuf/wire_format_lite.h
+  writeVarint32(bb, (value << 1) ^ (value >> 31));
+}
+
+function readVarint64ZigZag(bb: ByteBuffer): Long {
+  let value = readVarint64(bb, /* unsigned */ false);
+  let low = value.low;
+  let high = value.high;
+  let flip = -(low & 1);
+
+  // ref: src/google/protobuf/wire_format_lite.h
+  return {
+    low: ((low >>> 1) | (high << 31)) ^ flip,
+    high: (high >>> 1) ^ flip,
+    unsigned: false,
+  };
+}
+
+function writeVarint64ZigZag(bb: ByteBuffer, value: Long): void {
+  let low = value.low;
+  let high = value.high;
+  let flip = high >> 31;
+
+  // ref: src/google/protobuf/wire_format_lite.h
+  writeVarint64(bb, {
+    low: (low << 1) ^ flip,
+    high: ((high << 1) | (low >>> 31)) ^ flip,
+    unsigned: false,
+  });
 }

--- a/services/types/src/TradeModel.ts
+++ b/services/types/src/TradeModel.ts
@@ -1,23 +1,724 @@
-import { CurrencyPair } from './CurrencyPair';
-
 export const enum TradeSide {
-  Buy = 'buy',
-  Sell = 'sell',
+  buy = "buy",
+  sell = "sell",
 }
+
+export const encodeTradeSide: { [key: string]: number } = {
+  buy: 0,
+  sell: 1,
+};
+
+export const decodeTradeSide: { [key: number]: TradeSide } = {
+  0: TradeSide.buy,
+  1: TradeSide.sell,
+};
+
 export const enum OrderType {
-  Market = 'market',
-  Limit = 'limit',
+  market = "market",
+  limit = "limit",
 }
+
+export const encodeOrderType: { [key: string]: number } = {
+  market: 0,
+  limit: 1,
+};
+
+export const decodeOrderType: { [key: number]: OrderType } = {
+  0: OrderType.market,
+  1: OrderType.limit,
+};
+
 export const enum MarketType {
-  Kraken = 'kraken',
-  Bitfinex = 'bitfinex',
+  kraken = "kraken",
+  bitfinex = "bitfinex",
 }
+
+export const encodeMarketType: { [key: string]: number } = {
+  kraken: 0,
+  bitfinex: 1,
+};
+
+export const decodeMarketType: { [key: number]: MarketType } = {
+  0: MarketType.kraken,
+  1: MarketType.bitfinex,
+};
+
 export interface TradeModel {
-  pair: CurrencyPair;
-  price: number;
-  volume: number;
-  time: number;
-  side: TradeSide;
-  type: OrderType;
-  market: MarketType;
+  pair?: string;
+  price?: number;
+  volume?: number;
+  time?: number;
+  side?: TradeSide;
+  type?: OrderType;
+  market?: MarketType;
+}
+
+export function encodeTradeModel(message: TradeModel): Uint8Array {
+  let bb = popByteBuffer();
+  _encodeTradeModel(message, bb);
+  return toUint8Array(bb);
+}
+
+function _encodeTradeModel(message: TradeModel, bb: ByteBuffer): void {
+  // optional string pair = 1;
+  let $pair = message.pair;
+  if ($pair !== undefined) {
+    writeVarint32(bb, 10);
+    writeString(bb, $pair);
+  }
+
+  // optional float price = 2;
+  let $price = message.price;
+  if ($price !== undefined) {
+    writeVarint32(bb, 21);
+    writeFloat(bb, $price);
+  }
+
+  // optional float volume = 3;
+  let $volume = message.volume;
+  if ($volume !== undefined) {
+    writeVarint32(bb, 29);
+    writeFloat(bb, $volume);
+  }
+
+  // optional float time = 4;
+  let $time = message.time;
+  if ($time !== undefined) {
+    writeVarint32(bb, 37);
+    writeFloat(bb, $time);
+  }
+
+  // optional TradeSide side = 5;
+  let $side = message.side;
+  if ($side !== undefined) {
+    writeVarint32(bb, 40);
+    writeVarint32(bb, encodeTradeSide[$side]);
+  }
+
+  // optional OrderType type = 6;
+  let $type = message.type;
+  if ($type !== undefined) {
+    writeVarint32(bb, 48);
+    writeVarint32(bb, encodeOrderType[$type]);
+  }
+
+  // optional MarketType market = 7;
+  let $market = message.market;
+  if ($market !== undefined) {
+    writeVarint32(bb, 56);
+    writeVarint32(bb, encodeMarketType[$market]);
+  }
+}
+
+export function decodeTradeModel(binary: Uint8Array): TradeModel {
+  return _decodeTradeModel(wrapByteBuffer(binary));
+}
+
+function _decodeTradeModel(bb: ByteBuffer): TradeModel {
+  let message: TradeModel = {} as any;
+
+  end_of_message: while (!isAtEnd(bb)) {
+    let tag = readVarint32(bb);
+
+    switch (tag >>> 3) {
+      case 0:
+        break end_of_message;
+
+      // optional string pair = 1;
+      case 1: {
+        message.pair = readString(bb, readVarint32(bb));
+        break;
+      }
+
+      // optional float price = 2;
+      case 2: {
+        message.price = readFloat(bb);
+        break;
+      }
+
+      // optional float volume = 3;
+      case 3: {
+        message.volume = readFloat(bb);
+        break;
+      }
+
+      // optional float time = 4;
+      case 4: {
+        message.time = readFloat(bb);
+        break;
+      }
+
+      // optional TradeSide side = 5;
+      case 5: {
+        message.side = decodeTradeSide[readVarint32(bb)];
+        break;
+      }
+
+      // optional OrderType type = 6;
+      case 6: {
+        message.type = decodeOrderType[readVarint32(bb)];
+        break;
+      }
+
+      // optional MarketType market = 7;
+      case 7: {
+        message.market = decodeMarketType[readVarint32(bb)];
+        break;
+      }
+
+      default:
+        skipUnknownField(bb, tag & 7);
+    }
+  }
+
+  return message;
+}
+
+export interface TradeMessage {
+  models?: TradeModel[];
+}
+
+export function encodeTradeMessage(message: TradeMessage): Uint8Array {
+  let bb = popByteBuffer();
+  _encodeTradeMessage(message, bb);
+  return toUint8Array(bb);
+}
+
+function _encodeTradeMessage(message: TradeMessage, bb: ByteBuffer): void {
+  // repeated TradeModel models = 1;
+  let array$models = message.models;
+  if (array$models !== undefined) {
+    for (let value of array$models) {
+      writeVarint32(bb, 10);
+      let nested = popByteBuffer();
+      _encodeTradeModel(value, nested);
+      writeVarint32(bb, nested.limit);
+      writeByteBuffer(bb, nested);
+      pushByteBuffer(nested);
+    }
+  }
+}
+
+export function decodeTradeMessage(binary: Uint8Array): TradeMessage {
+  return _decodeTradeMessage(wrapByteBuffer(binary));
+}
+
+function _decodeTradeMessage(bb: ByteBuffer): TradeMessage {
+  let message: TradeMessage = {} as any;
+
+  end_of_message: while (!isAtEnd(bb)) {
+    let tag = readVarint32(bb);
+
+    switch (tag >>> 3) {
+      case 0:
+        break end_of_message;
+
+      // repeated TradeModel models = 1;
+      case 1: {
+        let limit = pushTemporaryLength(bb);
+        let values = message.models || (message.models = []);
+        values.push(_decodeTradeModel(bb));
+        bb.limit = limit;
+        break;
+      }
+
+      default:
+        skipUnknownField(bb, tag & 7);
+    }
+  }
+
+  return message;
+}
+
+export interface Long {
+  low: number;
+  high: number;
+  unsigned: boolean;
+}
+
+interface ByteBuffer {
+  bytes: Uint8Array;
+  offset: number;
+  limit: number;
+}
+
+function pushTemporaryLength(bb: ByteBuffer): number {
+  let length = readVarint32(bb);
+  let limit = bb.limit;
+  bb.limit = bb.offset + length;
+  return limit;
+}
+
+function skipUnknownField(bb: ByteBuffer, type: number): void {
+  switch (type) {
+    case 0: while (readByte(bb) & 0x80) { } break;
+    case 2: skip(bb, readVarint32(bb)); break;
+    case 5: skip(bb, 4); break;
+    case 1: skip(bb, 8); break;
+    default: throw new Error("Unimplemented type: " + type);
+  }
+}
+
+function stringToLong(value: string): Long {
+  return {
+    low: value.charCodeAt(0) | (value.charCodeAt(1) << 16),
+    high: value.charCodeAt(2) | (value.charCodeAt(3) << 16),
+    unsigned: false,
+  };
+}
+
+function longToString(value: Long): string {
+  let low = value.low;
+  let high = value.high;
+  return String.fromCharCode(
+    low & 0xFFFF,
+    low >>> 16,
+    high & 0xFFFF,
+    high >>> 16);
+}
+
+// The code below was modified from https://github.com/protobufjs/bytebuffer.js
+// which is under the Apache License 2.0.
+
+let f32 = new Float32Array(1);
+let f32_u8 = new Uint8Array(f32.buffer);
+
+let f64 = new Float64Array(1);
+let f64_u8 = new Uint8Array(f64.buffer);
+
+function intToLong(value: number): Long {
+  value |= 0;
+  return {
+    low: value,
+    high: value >> 31,
+    unsigned: value >= 0,
+  };
+}
+
+let bbStack: ByteBuffer[] = [];
+
+function popByteBuffer(): ByteBuffer {
+  const bb = bbStack.pop();
+  if (!bb) return { bytes: new Uint8Array(64), offset: 0, limit: 0 };
+  bb.offset = bb.limit = 0;
+  return bb;
+}
+
+function pushByteBuffer(bb: ByteBuffer): void {
+  bbStack.push(bb);
+}
+
+function wrapByteBuffer(bytes: Uint8Array): ByteBuffer {
+  return { bytes, offset: 0, limit: bytes.length };
+}
+
+function toUint8Array(bb: ByteBuffer): Uint8Array {
+  let bytes = bb.bytes;
+  let limit = bb.limit;
+  return bytes.length === limit ? bytes : bytes.subarray(0, limit);
+}
+
+function skip(bb: ByteBuffer, offset: number): void {
+  if (bb.offset + offset > bb.limit) {
+    throw new Error('Skip past limit');
+  }
+  bb.offset += offset;
+}
+
+function isAtEnd(bb: ByteBuffer): boolean {
+  return bb.offset >= bb.limit;
+}
+
+function grow(bb: ByteBuffer, count: number): number {
+  let bytes = bb.bytes;
+  let offset = bb.offset;
+  let limit = bb.limit;
+  let finalOffset = offset + count;
+  if (finalOffset > bytes.length) {
+    let newBytes = new Uint8Array(finalOffset * 2);
+    newBytes.set(bytes);
+    bb.bytes = newBytes;
+  }
+  bb.offset = finalOffset;
+  if (finalOffset > limit) {
+    bb.limit = finalOffset;
+  }
+  return offset;
+}
+
+function advance(bb: ByteBuffer, count: number): number {
+  let offset = bb.offset;
+  if (offset + count > bb.limit) {
+    throw new Error('Read past limit');
+  }
+  bb.offset += count;
+  return offset;
+}
+
+function readBytes(bb: ByteBuffer, count: number): Uint8Array {
+  let offset = advance(bb, count);
+  return bb.bytes.subarray(offset, offset + count);
+}
+
+function writeBytes(bb: ByteBuffer, buffer: Uint8Array): void {
+  let offset = grow(bb, buffer.length);
+  bb.bytes.set(buffer, offset);
+}
+
+function readString(bb: ByteBuffer, count: number): string {
+  // Sadly a hand-coded UTF8 decoder is much faster than subarray+TextDecoder in V8
+  let offset = advance(bb, count);
+  let fromCharCode = String.fromCharCode;
+  let bytes = bb.bytes;
+  let invalid = '\uFFFD';
+  let text = '';
+
+  for (let i = 0; i < count; i++) {
+    let c1 = bytes[i + offset], c2: number, c3: number, c4: number, c: number;
+
+    // 1 byte
+    if ((c1 & 0x80) === 0) {
+      text += fromCharCode(c1);
+    }
+
+    // 2 bytes
+    else if ((c1 & 0xE0) === 0xC0) {
+      if (i + 1 >= count) text += invalid;
+      else {
+        c2 = bytes[i + offset + 1];
+        if ((c2 & 0xC0) !== 0x80) text += invalid;
+        else {
+          c = ((c1 & 0x1F) << 6) | (c2 & 0x3F);
+          if (c < 0x80) text += invalid;
+          else {
+            text += fromCharCode(c);
+            i++;
+          }
+        }
+      }
+    }
+
+    // 3 bytes
+    else if ((c1 & 0xF0) == 0xE0) {
+      if (i + 2 >= count) text += invalid;
+      else {
+        c2 = bytes[i + offset + 1];
+        c3 = bytes[i + offset + 2];
+        if (((c2 | (c3 << 8)) & 0xC0C0) !== 0x8080) text += invalid;
+        else {
+          c = ((c1 & 0x0F) << 12) | ((c2 & 0x3F) << 6) | (c3 & 0x3F);
+          if (c < 0x0800 || (c >= 0xD800 && c <= 0xDFFF)) text += invalid;
+          else {
+            text += fromCharCode(c);
+            i += 2;
+          }
+        }
+      }
+    }
+
+    // 4 bytes
+    else if ((c1 & 0xF8) == 0xF0) {
+      if (i + 3 >= count) text += invalid;
+      else {
+        c2 = bytes[i + offset + 1];
+        c3 = bytes[i + offset + 2];
+        c4 = bytes[i + offset + 3];
+        if (((c2 | (c3 << 8) | (c4 << 16)) & 0xC0C0C0) !== 0x808080) text += invalid;
+        else {
+          c = ((c1 & 0x07) << 0x12) | ((c2 & 0x3F) << 0x0C) | ((c3 & 0x3F) << 0x06) | (c4 & 0x3F);
+          if (c < 0x10000 || c > 0x10FFFF) text += invalid;
+          else {
+            c -= 0x10000;
+            text += fromCharCode((c >> 10) + 0xD800, (c & 0x3FF) + 0xDC00);
+            i += 3;
+          }
+        }
+      }
+    }
+
+    else text += invalid;
+  }
+
+  return text;
+}
+
+function writeString(bb: ByteBuffer, text: string): void {
+  // Sadly a hand-coded UTF8 encoder is much faster than TextEncoder+set in V8
+  let n = text.length;
+  let byteCount = 0;
+
+  // Write the byte count first
+  for (let i = 0; i < n; i++) {
+    let c = text.charCodeAt(i);
+    if (c >= 0xD800 && c <= 0xDBFF && i + 1 < n) {
+      c = (c << 10) + text.charCodeAt(++i) - 0x35FDC00;
+    }
+    byteCount += c < 0x80 ? 1 : c < 0x800 ? 2 : c < 0x10000 ? 3 : 4;
+  }
+  writeVarint32(bb, byteCount);
+
+  let offset = grow(bb, byteCount);
+  let bytes = bb.bytes;
+
+  // Then write the bytes
+  for (let i = 0; i < n; i++) {
+    let c = text.charCodeAt(i);
+    if (c >= 0xD800 && c <= 0xDBFF && i + 1 < n) {
+      c = (c << 10) + text.charCodeAt(++i) - 0x35FDC00;
+    }
+    if (c < 0x80) {
+      bytes[offset++] = c;
+    } else {
+      if (c < 0x800) {
+        bytes[offset++] = ((c >> 6) & 0x1F) | 0xC0;
+      } else {
+        if (c < 0x10000) {
+          bytes[offset++] = ((c >> 12) & 0x0F) | 0xE0;
+        } else {
+          bytes[offset++] = ((c >> 18) & 0x07) | 0xF0;
+          bytes[offset++] = ((c >> 12) & 0x3F) | 0x80;
+        }
+        bytes[offset++] = ((c >> 6) & 0x3F) | 0x80;
+      }
+      bytes[offset++] = (c & 0x3F) | 0x80;
+    }
+  }
+}
+
+function writeByteBuffer(bb: ByteBuffer, buffer: ByteBuffer): void {
+  let offset = grow(bb, buffer.limit);
+  let from = bb.bytes;
+  let to = buffer.bytes;
+
+  // This for loop is much faster than subarray+set on V8
+  for (let i = 0, n = buffer.limit; i < n; i++) {
+    from[i + offset] = to[i];
+  }
+}
+
+function readByte(bb: ByteBuffer): number {
+  return bb.bytes[advance(bb, 1)];
+}
+
+function writeByte(bb: ByteBuffer, value: number): void {
+  let offset = grow(bb, 1);
+  bb.bytes[offset] = value;
+}
+
+function readFloat(bb: ByteBuffer): number {
+  let offset = advance(bb, 4);
+  let bytes = bb.bytes;
+
+  // Manual copying is much faster than subarray+set in V8
+  f32_u8[0] = bytes[offset++];
+  f32_u8[1] = bytes[offset++];
+  f32_u8[2] = bytes[offset++];
+  f32_u8[3] = bytes[offset++];
+  return f32[0];
+}
+
+function writeFloat(bb: ByteBuffer, value: number): void {
+  let offset = grow(bb, 4);
+  let bytes = bb.bytes;
+  f32[0] = value;
+
+  // Manual copying is much faster than subarray+set in V8
+  bytes[offset++] = f32_u8[0];
+  bytes[offset++] = f32_u8[1];
+  bytes[offset++] = f32_u8[2];
+  bytes[offset++] = f32_u8[3];
+}
+
+function readDouble(bb: ByteBuffer): number {
+  let offset = advance(bb, 8);
+  let bytes = bb.bytes;
+
+  // Manual copying is much faster than subarray+set in V8
+  f64_u8[0] = bytes[offset++];
+  f64_u8[1] = bytes[offset++];
+  f64_u8[2] = bytes[offset++];
+  f64_u8[3] = bytes[offset++];
+  f64_u8[4] = bytes[offset++];
+  f64_u8[5] = bytes[offset++];
+  f64_u8[6] = bytes[offset++];
+  f64_u8[7] = bytes[offset++];
+  return f64[0];
+}
+
+function writeDouble(bb: ByteBuffer, value: number): void {
+  let offset = grow(bb, 8);
+  let bytes = bb.bytes;
+  f64[0] = value;
+
+  // Manual copying is much faster than subarray+set in V8
+  bytes[offset++] = f64_u8[0];
+  bytes[offset++] = f64_u8[1];
+  bytes[offset++] = f64_u8[2];
+  bytes[offset++] = f64_u8[3];
+  bytes[offset++] = f64_u8[4];
+  bytes[offset++] = f64_u8[5];
+  bytes[offset++] = f64_u8[6];
+  bytes[offset++] = f64_u8[7];
+}
+
+function readInt32(bb: ByteBuffer): number {
+  let offset = advance(bb, 4);
+  let bytes = bb.bytes;
+  return (
+    bytes[offset] |
+    (bytes[offset + 1] << 8) |
+    (bytes[offset + 2] << 16) |
+    (bytes[offset + 3] << 24)
+  );
+}
+
+function writeInt32(bb: ByteBuffer, value: number): void {
+  let offset = grow(bb, 4);
+  let bytes = bb.bytes;
+  bytes[offset] = value;
+  bytes[offset + 1] = value >> 8;
+  bytes[offset + 2] = value >> 16;
+  bytes[offset + 3] = value >> 24;
+}
+
+function readInt64(bb: ByteBuffer, unsigned: boolean): Long {
+  return {
+    low: readInt32(bb),
+    high: readInt32(bb),
+    unsigned,
+  };
+}
+
+function writeInt64(bb: ByteBuffer, value: Long): void {
+  writeInt32(bb, value.low);
+  writeInt32(bb, value.high);
+}
+
+function readVarint32(bb: ByteBuffer): number {
+  let c = 0;
+  let value = 0;
+  let b: number;
+  do {
+    b = readByte(bb);
+    if (c < 32) value |= (b & 0x7F) << c;
+    c += 7;
+  } while (b & 0x80);
+  return value;
+}
+
+function writeVarint32(bb: ByteBuffer, value: number): void {
+  value >>>= 0;
+  while (value >= 0x80) {
+    writeByte(bb, (value & 0x7f) | 0x80);
+    value >>>= 7;
+  }
+  writeByte(bb, value);
+}
+
+function readVarint64(bb: ByteBuffer, unsigned: boolean): Long {
+  let part0 = 0;
+  let part1 = 0;
+  let part2 = 0;
+  let b: number;
+
+  b = readByte(bb); part0 = (b & 0x7F); if (b & 0x80) {
+    b = readByte(bb); part0 |= (b & 0x7F) << 7; if (b & 0x80) {
+      b = readByte(bb); part0 |= (b & 0x7F) << 14; if (b & 0x80) {
+        b = readByte(bb); part0 |= (b & 0x7F) << 21; if (b & 0x80) {
+
+          b = readByte(bb); part1 = (b & 0x7F); if (b & 0x80) {
+            b = readByte(bb); part1 |= (b & 0x7F) << 7; if (b & 0x80) {
+              b = readByte(bb); part1 |= (b & 0x7F) << 14; if (b & 0x80) {
+                b = readByte(bb); part1 |= (b & 0x7F) << 21; if (b & 0x80) {
+
+                  b = readByte(bb); part2 = (b & 0x7F); if (b & 0x80) {
+                    b = readByte(bb); part2 |= (b & 0x7F) << 7;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    low: part0 | (part1 << 28),
+    high: (part1 >>> 4) | (part2 << 24),
+    unsigned,
+  };
+}
+
+function writeVarint64(bb: ByteBuffer, value: Long): void {
+  let part0 = value.low >>> 0;
+  let part1 = ((value.low >>> 28) | (value.high << 4)) >>> 0;
+  let part2 = value.high >>> 24;
+
+  // ref: src/google/protobuf/io/coded_stream.cc
+  let size =
+    part2 === 0 ?
+      part1 === 0 ?
+        part0 < 1 << 14 ?
+          part0 < 1 << 7 ? 1 : 2 :
+          part0 < 1 << 21 ? 3 : 4 :
+        part1 < 1 << 14 ?
+          part1 < 1 << 7 ? 5 : 6 :
+          part1 < 1 << 21 ? 7 : 8 :
+      part2 < 1 << 7 ? 9 : 10;
+
+  let offset = grow(bb, size);
+  let bytes = bb.bytes;
+
+  switch (size) {
+    case 10: bytes[offset + 9] = (part2 >>> 7) & 0x01;
+    case 9: bytes[offset + 8] = size !== 9 ? part2 | 0x80 : part2 & 0x7F;
+    case 8: bytes[offset + 7] = size !== 8 ? (part1 >>> 21) | 0x80 : (part1 >>> 21) & 0x7F;
+    case 7: bytes[offset + 6] = size !== 7 ? (part1 >>> 14) | 0x80 : (part1 >>> 14) & 0x7F;
+    case 6: bytes[offset + 5] = size !== 6 ? (part1 >>> 7) | 0x80 : (part1 >>> 7) & 0x7F;
+    case 5: bytes[offset + 4] = size !== 5 ? part1 | 0x80 : part1 & 0x7F;
+    case 4: bytes[offset + 3] = size !== 4 ? (part0 >>> 21) | 0x80 : (part0 >>> 21) & 0x7F;
+    case 3: bytes[offset + 2] = size !== 3 ? (part0 >>> 14) | 0x80 : (part0 >>> 14) & 0x7F;
+    case 2: bytes[offset + 1] = size !== 2 ? (part0 >>> 7) | 0x80 : (part0 >>> 7) & 0x7F;
+    case 1: bytes[offset] = size !== 1 ? part0 | 0x80 : part0 & 0x7F;
+  }
+}
+
+function readVarint32ZigZag(bb: ByteBuffer): number {
+  let value = readVarint32(bb);
+
+  // ref: src/google/protobuf/wire_format_lite.h
+  return (value >>> 1) ^ -(value & 1);
+}
+
+function writeVarint32ZigZag(bb: ByteBuffer, value: number): void {
+  // ref: src/google/protobuf/wire_format_lite.h
+  writeVarint32(bb, (value << 1) ^ (value >> 31));
+}
+
+function readVarint64ZigZag(bb: ByteBuffer): Long {
+  let value = readVarint64(bb, /* unsigned */ false);
+  let low = value.low;
+  let high = value.high;
+  let flip = -(low & 1);
+
+  // ref: src/google/protobuf/wire_format_lite.h
+  return {
+    low: ((low >>> 1) | (high << 31)) ^ flip,
+    high: (high >>> 1) ^ flip,
+    unsigned: false,
+  };
+}
+
+function writeVarint64ZigZag(bb: ByteBuffer, value: Long): void {
+  let low = value.low;
+  let high = value.high;
+  let flip = high >> 31;
+
+  // ref: src/google/protobuf/wire_format_lite.h
+  writeVarint64(bb, {
+    low: (low << 1) ^ flip,
+    high: ((high << 1) | (low >>> 31)) ^ flip,
+    unsigned: false,
+  });
 }

--- a/services/types/src/index.ts
+++ b/services/types/src/index.ts
@@ -1,3 +1,3 @@
 export { CurrencyPair, isCurrencyPair } from './CurrencyPair';
-export { TradeModel, OrderType, TradeSide, MarketType } from './TradeModel';
-export { BookModel, BookSide } from './BookModel';
+export { TradeModel, OrderType, TradeSide, MarketType, TradeMessage, encodeTradeMessage, decodeTradeMessage } from './TradeModel';
+export { BookModel, BookSide, BookMessage, encodeBookMessage, decodeBookMessage } from './BookModel';


### PR DESCRIPTION
### Reasoning:
We are getting rid of [msgpack](https://msgpack.org/) in favour of [protobuf](https://developers.google.com/protocol-buffers) because of it's efficiency.<br>
To compare, msgpack compresses original message to 30% and protobuf to 60%<br>

### Changes
- Implemented protobuf in /types package (major)
- installed protobuf powered types in harvester to minimize rabbitmq payload and memory
- Limited rabbitmq memory stack to 100k messages (2.5m messages after 24 hours)
- Updated gh workflow to not fail on master if types major version did not change