### PR TITLE
AdSense and meta headers

### DIFF
--- a/services/client/public/index.html
+++ b/services/client/public/index.html
@@ -1,11 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <!-- <title>Bitcoin & Cryptocurrency Free Aggregator | TradePump.com</title> -->
+    <title>Bitcoin & Cryptocurrency Free Aggregator | TradePump.com</title>
+    <meta charSet="utf-8" />          
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="shortcut icon" href="/favicon.ico" />
+    <meta name="theme-color" content="#000000" />
+    <meta name="application-name" content="TradePump" />
+    <meta name="description" content="Tradepump is not just a Bitcoin and Cryptocurrency Free Aggregator. Come see why our servise is the best place to know crypto exchanges orders books and trades history." />
+    <meta name="robots" content="index,follow" />
+    <meta name="googlebot" content="index,follow" />
+    <meta name="google" content="notranslate" />
+    <meta name="generator" content="ReactJS"></meta>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" />
+    <link rel="stylesheet" href="/style.css" />
+    <meta property="og:type" content="website" />
+    <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
   </head>
   <body>
     <noscript>
-      You need to enable JavaScript to run this app.
+      Tradepump is not just a Bitcoin and Cryptocurrency Free Aggregator. <br/>
+      Come see why our servise is the best place to know crypto exchanges orders books and trades history.<br/>
+      <strong>You need to enable JavaScript to run this app.</strong>
     </noscript>
     <div id="root"></div>
   </body>

--- a/services/client/src/components/AdsComponent.tsx
+++ b/services/client/src/components/AdsComponent.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+const DEFAULT_AD_CLIENT = 'ca-pub-4950025876386607';
+
+declare global {
+  interface Window {
+    adsbygoogle: unknown[];
+  }
+}
+
+type AdFormat = 'vertical' | 'horizontal' | 'rectangle';
+type X = Exclude<AdFormat, 'vertical'>;
+
+
+interface Props {
+  adClient?: string;
+  adHost?: string;
+  adSlot?: string;
+  adFormat?: 'auto' | AdFormat | [AdFormat, AdFormat];
+  style?: React.CSSProperties;
+  className?: string;
+}
+
+export class AdsComponent extends React.Component<Props> {
+  static defaultProps: Props = {
+    style: {display: 'block'},
+  };
+
+  componentDidMount () {
+    window.adsbygoogle = window.adsbygoogle || [];
+    window.adsbygoogle.push({});
+  }
+
+  render () {
+    const { adClient, adSlot, adFormat, adHost, style, className } = this.props;
+    const classNames = ['adsbygoogle'];
+
+    if (className) {
+      classNames.push(className);
+    }
+    const format = Array.isArray(adFormat) ? adFormat.join(',') : adFormat;
+
+    return (
+        <ins className={classNames.join(' ')}
+          style={style}
+          data-ad-host={adHost}
+          data-ad-client={adClient || DEFAULT_AD_CLIENT}
+          data-ad-slot={adSlot}
+          data-ad-format={format}
+        />
+    );
+  }
+}

--- a/services/client/src/components/OrdersMonitor.tsx
+++ b/services/client/src/components/OrdersMonitor.tsx
@@ -90,21 +90,8 @@ export const OrdersMonitor = () => {
     return (
       <div>
         <Helmet>
-          <meta charSet="utf-8" />          
-          <meta name="viewport" content="width=device-width, initial-scale=1" />
-          <link rel="shortcut icon" href="./favicon.ico" />
-          <meta name="theme-color" content="#000000" />
-          <meta name="application-name" content="TradePump" />
-          <meta name="description" content="Tradepump is not just a Bitcoin and Cryptocurrency Free Aggregator. Come see why our servise is the best place to know crypto exchanges orders books and trades history." />
-          <meta name="robots" content="index,follow" />
-          <meta name="googlebot" content="index,follow" />
-          <meta name="google" content="notranslate" />
-          <meta name="generator" content="ReactJS"></meta>
-          <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" />
-          <link rel="stylesheet" href="style.css" />
           <title>Bitcoin & Cryptocurrency Free Aggregator | TradePump.com</title>
           <meta property="og:title" content="Bitcoin & Cryptocurrency Aggregator | TradePump.com" />
-          <meta property="og:type" content="website" />
           <meta property="og:url" content="https://www.tradepump.com/" />
           <meta property="og:image" content="https://www.tradepump.com/android-chrome-192x192.png" />
           <meta property="og:description" content="Tradepump is not just a Bitcoin and Cryptocurrency Aggregator. Come see why our servise is the best place to know crypto exchanges orders books and trades history." />

--- a/services/client/src/components/RightAd.tsx
+++ b/services/client/src/components/RightAd.tsx
@@ -1,6 +1,7 @@
 // import { BorderColor } from '@material-ui/icons';
 import React from 'react';
 import './../../src/css/index.css';
+import { AdsComponent } from './AdsComponent';
 // import { ChangeEvent, useState } from 'react';
 // import { GridList, Checkbox, FormControlLabel, TextField } from '@material-ui/core';
 // import { themeStyles } from '../style/postcss';
@@ -8,10 +9,9 @@ import './../../src/css/index.css';
 
 export const RightAd = () => {
   return (
-    <div style={{ visibility: 'visible', display: 'inline-block', borderColor: 'black' }}>
-      {/* <script data-ad-client="ca-pub-4950025876386607" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script> */}
+    <AdsComponent style={{ visibility: 'visible', display: 'inline-block', borderColor: 'black' }}>
       {/* <p>Please disable your ad-blocker! (adv 160*600 align bottom)</p>
       <p>You may not like this ad, but it supports the developer and keeps this site free.</p> */}
-    </div>
+    </AdsComponent>
   );
 };

--- a/services/client/src/components/TopAd.tsx
+++ b/services/client/src/components/TopAd.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import './../../src/css/index.css';
+import { AdsComponent } from './AdsComponent';
 // import { ChangeEvent, useState } from 'react';
 // import { GridList, Checkbox, FormControlLabel, TextField } from '@material-ui/core';
 // import { themeStyles } from '../style/postcss';
@@ -8,11 +9,10 @@ import './../../src/css/index.css';
 export const TopAd = () => {
   return (
     <div>
-      <div className="topadv">
-        {/* <script data-ad-client="ca-pub-4950025876386607" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script> */}
+      <AdsComponent adFormat='auto' className="topadv">
         {/* <p>Please disable your ad-blocker (adv 728*90 align=right)</p>
         <p>You may not like this ad, but it supports the developer and keeps this site free.</p> */}
-      </div>
+      </AdsComponent>
     </div>
   );
 };


### PR DESCRIPTION
- Added AdsComponent to support AdSense ad tags: https://developers.google.com/adsense/platforms/transparent/ad-tags
- Moved *common* meta headers and scripts to index.html
- Updated `TopAd` and `RightAd` with `AdsComponent`